### PR TITLE
add support for `set-ptr` option in request to PoweDNS API

### DIFF
--- a/powerdns/client.go
+++ b/powerdns/client.go
@@ -86,6 +86,7 @@ type Record struct {
 	Content  string `json:"content"`
 	TTL      int    `json:"ttl"` // For API v0
 	Disabled bool   `json:"disabled"`
+	SetPtr   bool   `json:"set-ptr"`
 }
 
 type ResourceRecordSet struct {

--- a/powerdns/resource_powerdns_record.go
+++ b/powerdns/resource_powerdns_record.go
@@ -47,6 +47,13 @@ func resourcePDNSRecord() *schema.Resource {
 				ForceNew: true,
 				Set:      schema.HashString,
 			},
+
+			"set_ptr": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "For A and AAAA records, if true, create corresponding PTR.",
+			},
 		},
 	}
 }
@@ -63,11 +70,15 @@ func resourcePDNSRecordCreate(d *schema.ResourceData, meta interface{}) error {
 	zone := d.Get("zone").(string)
 	ttl := d.Get("ttl").(int)
 	recs := d.Get("records").(*schema.Set).List()
+	set_ptr := false
+	if v, ok := d.GetOk("set_ptr"); ok {
+		set_ptr = v.(bool)
+	}
 
 	if len(recs) > 0 {
 		records := make([]Record, 0, len(recs))
 		for _, recContent := range recs {
-			records = append(records, Record{Name: rrSet.Name, Type: rrSet.Type, TTL: ttl, Content: recContent.(string)})
+			records = append(records, Record{Name: rrSet.Name, Type: rrSet.Type, TTL: ttl, Content: recContent.(string), SetPtr: set_ptr})
 		}
 		rrSet.Records = records
 

--- a/powerdns/resource_powerdns_record_test.go
+++ b/powerdns/resource_powerdns_record_test.go
@@ -24,6 +24,22 @@ func TestAccPDNSRecord_A(t *testing.T) {
 	})
 }
 
+func TestAccPDNSRecord_WithPtr(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPDNSRecordDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testPDNSRecordConfigAWithPtr,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPDNSRecordExists("powerdns_record.test-a-ptr"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccPDNSRecord_WithCount(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -277,6 +293,16 @@ resource "powerdns_record" "test-a" {
 	type = "A"
 	ttl = 60
 	records = [ "1.1.1.1", "2.2.2.2" ]
+}`
+
+const testPDNSRecordConfigAWithPtr = `
+resource "powerdns_record" "test-a-ptr" {
+	zone = "sysa.xyz"
+	name = "redis.sysa.xyz"
+	type = "A"
+	ttl = 60
+	set_ptr = true
+	records = [ "1.1.1.1" ]
 }`
 
 const testPDNSRecordConfigHyphenedWithCount = `

--- a/website/docs/r/record.html.markdown
+++ b/website/docs/r/record.html.markdown
@@ -39,6 +39,20 @@ resource "powerdns_record" "foobar" {
 }
 ```
 
+There is a feature in PowerDNS API for A/AAAA records to automatically create corresponding PTR records.
+Existing PTR records with same name are replaced. If no matching reverse zone found, an error is thrown by API and thus Terraform. Example:
+
+```hcl
+resource "powerdns_record" "foobar" {
+  zone    = "example.com."
+  name    = "www.example.com"
+  type    = "A"
+  ttl     = 300
+  set_ptr = true
+  records = ["192.168.0.11"]
+}
+```
+
 For the legacy API (PowerDNS version 3.4):
 
 ```hcl


### PR DESCRIPTION
According to PowerDNS API specification
set-ptr: If set to true, the server will find the matching reverse zone
and create a PTR there. Existing PTR records are replaced. If no
matching reverse Zone, an error is thrown. Only valid in client bodies,
only valid for A and AAAA types. Not returned by the server. Only valid
for the Authoritative server.
See https://doc.powerdns.com/md/httpapi/api_spec/